### PR TITLE
Amélioration du script borg_setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ for f in ~/.mon_shell/*.sh; do source "$f"; done
 Exécutez le script d'installation en tant que root :
 
 ```bash
-sudo ./borg_setup.sh
+sudo ./borg_setup.sh [chemin_relatif]
 ```
 
-Le script crée un dépôt chiffré dans `~/kDrive/INFORMATIQUE/PC_TUF/borgrepo`,
-installe les scripts de sauvegarde/restauration dans `/usr/local/sbin/` et active
-le timer systemd `borg-backup.timer` (tous les jours à 02:30).
+Par défaut, le dépôt est créé dans `~/kDrive/INFORMATIQUE/PC_TUF/borgrepo`.
+Vous pouvez spécifier un autre dossier relatif en argument.
+Le script installe également les utilitaires de sauvegarde/restauration dans
+`/usr/local/sbin/` et active le timer systemd `borg-backup.timer`
+ (tous les jours à 02:30).
 Les journaux se trouvent dans `/var/log/borg_backup.log`.
 
 ## Correctif PipeWire Bluetooth

--- a/borg_setup.sh
+++ b/borg_setup.sh
@@ -7,6 +7,11 @@
 # ------------------------------------------------------------
 set -euo pipefail
 
+# Chemin relatif par défaut pour le dépôt Borg dans le home de l'utilisateur
+CHEMIN_RELATIF_DEF="kDrive/INFORMATIQUE/PC_TUF"
+# Permettre la personnalisation via un argument optionnel
+CHEMIN_RELATIF="${1:-$CHEMIN_RELATIF_DEF}"
+
 # -------- Fonctions utilitaires --------
 
 verifier_root() {
@@ -28,7 +33,8 @@ installer_borg() {
 }
 
 preparer_dossiers() {
-  CHEMIN_KDRIVE="$DOSSIER_HOME/kDrive/INFORMATIQUE/PC_TUF"
+  # Dossier qui contiendra le dépôt Borg
+  CHEMIN_KDRIVE="$DOSSIER_HOME/$CHEMIN_RELATIF"
   DEPOT_BORG="$CHEMIN_KDRIVE/borgrepo"
   mkdir -p "$DEPOT_BORG"
   chown -R "$UTILISATEUR":"$UTILISATEUR" "$CHEMIN_KDRIVE"
@@ -66,14 +72,14 @@ initialiser_depot() {
 }
 
 creer_script_backup() {
-  cat > /usr/local/sbin/borg_backup.sh <<'EOS'
+  cat > /usr/local/sbin/borg_backup.sh <<EOS
 #!/bin/bash
 set -euo pipefail
 # shellcheck source=/etc/borgbackup.conf
 source /etc/borgbackup.conf
 export BORG_REPO BORG_PASSPHRASE
 LOG="/var/log/borg_backup.log"
-CHEMIN_KDRIVE="'$CHEMIN_KDRIVE'"
+CHEMIN_KDRIVE="$CHEMIN_KDRIVE"
 
 horodatage() { date '+%Y-%m-%d %H:%M:%S'; }
 
@@ -100,7 +106,7 @@ EOS
 }
 
 creer_script_restore() {
-  cat > /usr/local/sbin/borg_restore.sh <<'EOS'
+  cat > /usr/local/sbin/borg_restore.sh <<EOS
 #!/bin/bash
 set -euo pipefail
 # shellcheck source=/etc/borgbackup.conf


### PR DESCRIPTION
## Résumé
- paramétrage du chemin du dépôt Borg via un argument optionnel
- correction de l'expansion des variables lors de la génération des scripts
- mise à jour du README avec ces indications

## Tests
- `bash -n borg_setup.sh`
- `bash -n script/son/fix_pipewire_bt.sh`
- `bash -n mon_shell/aliases.sh`


------
https://chatgpt.com/codex/tasks/task_e_68878392dab4832fa011924786869509